### PR TITLE
Switch to SQLAlchemy storage and add flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Telegram bot for connecting drivers and passengers for city-to-city ride shari
 pip install -r requirements.txt
 ```
 
-2. Fill `config.json` with your bot token and cities.
+2. Fill `config.json` with your bot token, database connection string and cities.
 
 3. Run the bot:
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -10,6 +10,7 @@ class Config:
     default_language: str = 'ru'
     cities: List[str] = field(default_factory=list)
     followup_delay: int = 120  # seconds
+    db_url: str = 'postgresql+asyncpg://user:password@localhost/hitchhiker'
 
     @classmethod
     def load(cls, path: str | Path) -> 'Config':

--- a/bot/handlers/driver.py
+++ b/bot/handlers/driver.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import uuid
 from aiogram import Router, F
 from aiogram.fsm.state import StatesGroup, State
-from aiogram.types import Message, CallbackQuery
-from ..storage import Trip, MemoryStorage
+from aiogram.types import Message
+from ..storage import Trip
 from ..utils import validate_phone
 from datetime import date
 
@@ -66,7 +66,7 @@ async def set_phone(message: Message, state):
         photos=[],
         comment=None,
     )
-    storage: MemoryStorage = message.bot['storage']
-    storage.create_trip(trip)
+    storage = message.bot['storage']
+    await storage.create_trip(trip)
     await message.answer('Поездка создана')
     await state.clear()

--- a/bot/handlers/followup.py
+++ b/bot/handlers/followup.py
@@ -3,6 +3,7 @@ from aiogram.types import CallbackQuery
 
 router = Router()
 
+
 @router.callback_query()
 async def show_number(callback: CallbackQuery):
     await callback.answer('номер раскрыт')

--- a/bot/handlers/my_trips.py
+++ b/bot/handlers/my_trips.py
@@ -1,14 +1,14 @@
 from aiogram import Router, F
 from aiogram.types import Message
-from ..storage import MemoryStorage
+from ..storage import Storage
 
 router = Router()
 
 
 @router.message(F.text == '/my_trips')
 async def list_trips(message: Message):
-    storage: MemoryStorage = message.bot['storage']
-    trips = storage.list_driver_trips(message.from_user.id)
+    storage: Storage = message.bot['storage']
+    trips = await storage.list_driver_trips(message.from_user.id)
     if not trips:
         await message.answer('У вас нет активных поездок')
     else:

--- a/bot/handlers/passenger.py
+++ b/bot/handlers/passenger.py
@@ -1,7 +1,7 @@
 from aiogram import Router, F
 from aiogram.types import Message
 from datetime import date
-from ..storage import MemoryStorage
+from ..storage import Storage
 
 router = Router()
 
@@ -14,8 +14,8 @@ async def cmd_search(message: Message):
 @router.message()
 async def handle_city(message: Message):
     # simplified search handler
-    storage: MemoryStorage = message.bot['storage']
-    trips = storage.search_trips(message.text, message.text, date.today())
+    storage: Storage = message.bot['storage']
+    trips = await storage.search_trips(message.text, message.text, date.today())
     if not trips:
         await message.answer('Не найдено')
         return

--- a/bot/main.py
+++ b/bot/main.py
@@ -3,7 +3,7 @@ from aiogram import Bot, Dispatcher
 from aiogram.client.bot import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage as FSMStorage
 from .config import Config
-from .storage import MemoryStorage
+from .storage import SQLStorage
 from .handlers import language, driver, passenger, followup, my_trips
 
 
@@ -13,7 +13,7 @@ async def main() -> None:
               default=DefaultBotProperties(parse_mode='HTML'))
     dp = Dispatcher(storage=FSMStorage())
 
-    storage = MemoryStorage()
+    storage = await SQLStorage.create(config.db_url)
     dp['config'] = config
     dp['storage'] = storage
 

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -1,9 +1,28 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
-from datetime import date, datetime, time
+from datetime import date, datetime, time as dt_time
 from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 from threading import Lock
+from sqlalchemy import (
+    Date,
+    DateTime,
+    Integer,
+    String,
+    Time,
+    JSON,
+    ForeignKey,
+    select,
+    delete,
+    update,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
 FileID = str
@@ -16,7 +35,7 @@ class Trip:
     from_city: str
     to_city: str
     date: date
-    time: Optional[time]
+    time: Optional[dt_time]
     seats: int
     price: Optional[str]
     phone: str
@@ -27,25 +46,25 @@ class Trip:
 
 
 class Storage:
-    def create_trip(self, trip: Trip) -> None:
+    async def create_trip(self, trip: Trip) -> None:
         raise NotImplementedError
 
-    def search_trips(self, from_city: str, to_city: str, date: date) -> List[Trip]:
+    async def search_trips(self, from_city: str, to_city: str, date: date) -> List[Trip]:
         raise NotImplementedError
 
-    def get_trip(self, trip_id: UUID) -> Optional[Trip]:
+    async def get_trip(self, trip_id: UUID) -> Optional[Trip]:
         raise NotImplementedError
 
-    def delete_trip(self, trip_id: UUID) -> None:
+    async def delete_trip(self, trip_id: UUID) -> None:
         raise NotImplementedError
 
-    def update_trip(self, trip_id: UUID, data: dict) -> None:
+    async def update_trip(self, trip_id: UUID, data: dict) -> None:
         raise NotImplementedError
 
-    def list_driver_trips(self, driver_id: int) -> List[Trip]:
+    async def list_driver_trips(self, driver_id: int) -> List[Trip]:
         raise NotImplementedError
 
-    def record_contact(self, trip_id: UUID, passenger_id: int) -> None:
+    async def record_contact(self, trip_id: UUID, passenger_id: int) -> None:
         raise NotImplementedError
 
 
@@ -55,27 +74,27 @@ class MemoryStorage(Storage):
         self._contacts: Dict[UUID, List[int]] = {}
         self._lock = Lock()
 
-    def create_trip(self, trip: Trip) -> None:
+    async def create_trip(self, trip: Trip) -> None:
         with self._lock:
             self._trips[trip.id] = trip
 
-    def search_trips(self, from_city: str, to_city: str, date: date) -> List[Trip]:
+    async def search_trips(self, from_city: str, to_city: str, date: date) -> List[Trip]:
         with self._lock:
             return [
                 t for t in self._trips.values()
                 if t.from_city == from_city and t.to_city == to_city and t.date == date
             ]
 
-    def get_trip(self, trip_id: UUID) -> Optional[Trip]:
+    async def get_trip(self, trip_id: UUID) -> Optional[Trip]:
         with self._lock:
             return self._trips.get(trip_id)
 
-    def delete_trip(self, trip_id: UUID) -> None:
+    async def delete_trip(self, trip_id: UUID) -> None:
         with self._lock:
             self._trips.pop(trip_id, None)
             self._contacts.pop(trip_id, None)
 
-    def update_trip(self, trip_id: UUID, data: dict) -> None:
+    async def update_trip(self, trip_id: UUID, data: dict) -> None:
         with self._lock:
             trip = self._trips.get(trip_id)
             if not trip:
@@ -83,10 +102,129 @@ class MemoryStorage(Storage):
             for k, v in data.items():
                 setattr(trip, k, v)
 
-    def list_driver_trips(self, driver_id: int) -> List[Trip]:
+    async def list_driver_trips(self, driver_id: int) -> List[Trip]:
         with self._lock:
             return [t for t in self._trips.values() if t.driver_id == driver_id]
 
-    def record_contact(self, trip_id: UUID, passenger_id: int) -> None:
+    async def record_contact(self, trip_id: UUID, passenger_id: int) -> None:
         with self._lock:
             self._contacts.setdefault(trip_id, []).append(passenger_id)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class TripModel(Base):
+    __tablename__ = 'trips'
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
+    driver_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    from_city: Mapped[str] = mapped_column(String, nullable=False)
+    to_city: Mapped[str] = mapped_column(String, nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    time: Mapped[Optional[dt_time]] = mapped_column(Time)
+    seats: Mapped[int] = mapped_column(Integer, nullable=False)
+    price: Mapped[Optional[str]] = mapped_column(String)
+    phone: Mapped[str] = mapped_column(String, nullable=False)
+    car: Mapped[Optional[str]] = mapped_column(String)
+    photos: Mapped[List[FileID]] = mapped_column(JSON, nullable=False)
+    comment: Mapped[Optional[str]] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    @classmethod
+    def from_dataclass(cls, trip: Trip) -> 'TripModel':
+        return cls(
+            id=trip.id,
+            driver_id=trip.driver_id,
+            from_city=trip.from_city,
+            to_city=trip.to_city,
+            date=trip.date,
+            time=trip.time,
+            seats=trip.seats,
+            price=trip.price,
+            phone=trip.phone,
+            car=trip.car,
+            photos=trip.photos,
+            comment=trip.comment,
+            created_at=trip.created_at,
+        )
+
+    def to_dataclass(self) -> Trip:
+        return Trip(
+            id=self.id,
+            driver_id=self.driver_id,
+            from_city=self.from_city,
+            to_city=self.to_city,
+            date=self.date,
+            time=self.time,
+            seats=self.seats,
+            price=self.price,
+            phone=self.phone,
+            car=self.car,
+            photos=self.photos,
+            comment=self.comment,
+            created_at=self.created_at,
+        )
+
+
+class ContactModel(Base):
+    __tablename__ = 'contacts'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    trip_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), ForeignKey('trips.id'))
+    passenger_id: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+class SQLStorage(Storage):
+    def __init__(self, session_maker: async_sessionmaker[AsyncSession]):
+        self._session_maker = session_maker
+
+    @classmethod
+    async def create(cls, url: str) -> 'SQLStorage':
+        engine = create_async_engine(url)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        session_maker = async_sessionmaker(engine, expire_on_commit=False)
+        return cls(session_maker)
+
+    async def create_trip(self, trip: Trip) -> None:
+        async with self._session_maker() as session:
+            session.add(TripModel.from_dataclass(trip))
+            await session.commit()
+
+    async def search_trips(self, from_city: str, to_city: str, date_: date) -> List[Trip]:
+        async with self._session_maker() as session:
+            result = await session.execute(
+                select(TripModel).where(
+                    TripModel.from_city == from_city,
+                    TripModel.to_city == to_city,
+                    TripModel.date == date_,
+                )
+            )
+            return [row[0].to_dataclass() for row in result.all()]
+
+    async def get_trip(self, trip_id: UUID) -> Optional[Trip]:
+        async with self._session_maker() as session:
+            obj = await session.get(TripModel, trip_id)
+            return obj.to_dataclass() if obj else None
+
+    async def delete_trip(self, trip_id: UUID) -> None:
+        async with self._session_maker() as session:
+            await session.execute(delete(TripModel).where(TripModel.id == trip_id))
+            await session.commit()
+
+    async def update_trip(self, trip_id: UUID, data: dict) -> None:
+        async with self._session_maker() as session:
+            await session.execute(update(TripModel).where(TripModel.id == trip_id).values(**data))
+            await session.commit()
+
+    async def list_driver_trips(self, driver_id: int) -> List[Trip]:
+        async with self._session_maker() as session:
+            result = await session.execute(select(TripModel).where(TripModel.driver_id == driver_id))
+            return [row[0].to_dataclass() for row in result.all()]
+
+    async def record_contact(self, trip_id: UUID, passenger_id: int) -> None:
+        async with self._session_maker() as session:
+            session.add(ContactModel(trip_id=trip_id, passenger_id=passenger_id))
+            await session.commit()

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,6 +1,8 @@
+import asyncio
 import re
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from typing import Iterable
+
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 
 PHONE_REGEX = re.compile(r'^\+?\d{9,15}$')
@@ -20,7 +22,6 @@ def build_keyboard(buttons: Iterable[tuple[str, str]]) -> InlineKeyboardMarkup:
         inline_keyboard=[[InlineKeyboardButton(text=text, callback_data=data)] for text, data in buttons]
     )
 
-import asyncio
 
 async def schedule_followup(bot, chat_id: int, text: str, delay: int, keyboard: InlineKeyboardMarkup | None = None):
     await asyncio.sleep(delay)

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "token": "YOUR_TELEGRAM_BOT_TOKEN",
   "default_language": "ru",
   "cities": ["Bishkek", "Osh", "Jalal-Abad"],
-  "followup_delay": 120
+  "followup_delay": 120,
+  "db_url": "postgresql+asyncpg://user:password@localhost/hitchhiker"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 aiogram>=3.7
+sqlalchemy>=2.0
+asyncpg
+flake8
 


### PR DESCRIPTION
## Summary
- migrate from in-memory storage to SQLAlchemy backed by PostgreSQL
- update bot handlers to use async storage
- support database configuration via `config.json`
- document database setup in README
- add flake8 configuration with 119 char line limit

## Testing
- `pip install -r requirements.txt`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68400d78d554832394673df2546f9458