### PR TITLE
Implement ride sharing bot MVP

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,17 +1,16 @@
+# flake8: noqa
 import asyncio
 import sys
 from logging.config import fileConfig
 from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from sqlalchemy import engine_from_config
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.pool import NullPool
 
 from alembic import context
-
-# Add project root to sys.path for bot.storage import
-# This needs to be before importing from 'bot'
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from bot.storage import Base
 
 config = context.config

--- a/alembic/versions/c6e500703796_rename_date_to_departure_date_in_trips.py
+++ b/alembic/versions/c6e500703796_rename_date_to_departure_date_in_trips.py
@@ -1,7 +1,7 @@
 """rename_date_to_departure_date_in_trips
 
 Revision ID: c6e500703796
-Revises: 
+Revises:
 Create Date: 2025-06-04 15:34:52.936642
 
 """

--- a/bot/handlers/driver.py
+++ b/bot/handlers/driver.py
@@ -1,73 +1,246 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import date, timedelta, time as dt_time
 
 from aiogram import F, Router
-from aiogram.fsm.state import State, StatesGroup
-from aiogram.types import Message
+from aiogram.filters.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, Message
 
+from ..config import Config
+from ..i18n import t
 from ..storage import Storage, Trip
-from ..utils import validate_phone
+from ..utils import build_keyboard, validate_phone, validate_time
 
 router = Router()
+
+SKIP = {"ru": "Пропустить", "kg": "Өткөрүү"}
+AGREE = {"ru": "💬 Договорная", "kg": "💬 Келишимдүү"}
 
 
 class CreateTrip(StatesGroup):
     from_city = State()
     to_city = State()
-    departure_date = State()
+    date = State()
+    time = State()
+    seats = State()
+    price = State()
+    car = State()
+    photos = State()
     phone = State()
+    comment = State()
     confirm = State()
 
 
-@router.message(F.text == 'create')
-async def cmd_create(message: Message, state):
+def city_kb(cfg: Config) -> list[tuple[str, str]]:
+    return [(c, f"city:{c}") for c in cfg.cities]
+
+
+def seats_kb() -> list[tuple[str, str]]:
+    return [(str(i), f"seats:{i}") for i in range(1, 6)] + [("5+", "seats:5")]  # 5 means 5 or more
+
+
+@router.message(F.text.startswith("🚗"))
+async def start_create(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
     await state.set_state(CreateTrip.from_city)
-    await message.answer('Откуда?')
+    kb = build_keyboard(city_kb(config))
+    await message.answer(t(lang, "driver.from_city"), reply_markup=kb)
 
 
-@router.message(CreateTrip.from_city)
-async def set_from_city(message: Message, state):
-    await state.update_data(from_city=message.text)
+@router.callback_query(CreateTrip.from_city, F.data.startswith("city:"))
+async def set_from(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    await state.update_data(from_city=callback.data.split(":", 1)[1])
     await state.set_state(CreateTrip.to_city)
-    await message.answer('Куда?')
+    await callback.message.edit_text(t(lang, "driver.to_city"), reply_markup=build_keyboard(city_kb(config)))
+    await callback.answer()
 
 
-@router.message(CreateTrip.to_city)
-async def set_to_city(message: Message, state):
-    await state.update_data(to_city=message.text)
-    await state.set_state(CreateTrip.departure_date)
-    await message.answer('Дата в формате YYYY-MM-DD')
+@router.callback_query(CreateTrip.to_city, F.data.startswith("city:"))
+async def set_to(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    await state.update_data(to_city=callback.data.split(":", 1)[1])
+    await state.set_state(CreateTrip.date)
+    buttons = [
+        ("Сегодня", "date:0"),
+        ("Завтра", "date:1"),
+        ("Введите дату", "date:manual"),
+    ]
+    await callback.message.edit_text(t(lang, "driver.date"), reply_markup=build_keyboard(buttons))
+    await callback.answer()
 
 
-@router.message(CreateTrip.departure_date)
-async def set_departure_date(message: Message, state):
-    await state.update_data(departure_date=message.text)
-    await state.set_state(CreateTrip.phone)
-    await message.answer('Номер телефона')
+@router.callback_query(CreateTrip.date, F.data.startswith("date:"))
+async def choose_date(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    data = callback.data.split(":", 1)[1]
+    if data == "manual":
+        await callback.message.edit_text(t(lang, "driver.date") + " YYYY-MM-DD")
+        await state.set_state(CreateTrip.date)
+        await state.update_data(manual_date=True)
+    else:
+        days = int(data)
+        await state.update_data(date=date.today() + timedelta(days=days), manual_date=False)
+        await state.set_state(CreateTrip.time)
+        await callback.message.edit_text(t(lang, "driver.time"))
+    await callback.answer()
+
+
+@router.message(CreateTrip.date)
+async def manual_date(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    try:
+        chosen = date.fromisoformat(message.text)
+    except ValueError:
+        await message.answer(t(lang, "driver.date") + " YYYY-MM-DD")
+        return
+    await state.update_data(date=chosen)
+    await state.set_state(CreateTrip.time)
+    await message.answer(t(lang, "driver.time"))
+
+
+@router.message(CreateTrip.time)
+async def set_time(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    if message.text == SKIP[lang]:
+        await state.update_data(time=None)
+    elif validate_time(message.text):
+        await state.update_data(time=dt_time.fromisoformat(message.text))
+    else:
+        await message.answer(t(lang, "driver.time"))
+        return
+    await state.set_state(CreateTrip.seats)
+    await message.answer(t(lang, "driver.seats"), reply_markup=build_keyboard(seats_kb()))
+
+
+@router.callback_query(CreateTrip.seats, F.data.startswith("seats:"))
+async def set_seats(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    seats = int(callback.data.split(":", 1)[1])
+    await state.update_data(seats=seats)
+    await state.set_state(CreateTrip.price)
+    kb = build_keyboard([(AGREE[lang], "price:none")])
+    await callback.message.edit_text(t(lang, "driver.price"), reply_markup=kb)
+    await callback.answer()
+
+
+@router.callback_query(CreateTrip.price, F.data.startswith("price:none"))
+async def price_agree(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    await state.update_data(price=None)
+    await state.set_state(CreateTrip.car)
+    await callback.message.edit_text(t(lang, "driver.car"))
+    await callback.answer()
+
+
+@router.message(CreateTrip.price)
+async def set_price(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    await state.update_data(price=message.text)
+    await state.set_state(CreateTrip.car)
+    await message.answer(t(lang, "driver.car"))
+
+
+@router.message(CreateTrip.car)
+async def set_car(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    if message.text == SKIP[lang]:
+        await state.update_data(car=None)
+    else:
+        await state.update_data(car=message.text)
+    await state.set_state(CreateTrip.photos)
+    await message.answer(t(lang, "driver.photos"))
+
+
+@router.message(CreateTrip.photos, F.photo)
+async def collect_photo(message: Message, state: FSMContext, storage: Storage, config: Config) -> None:
+    data = await state.get_data()
+    photos = data.get("photos", [])
+    photos.append(message.photo[-1].file_id)
+    if len(photos) >= 3:
+        await state.update_data(photos=photos)
+        await state.set_state(CreateTrip.phone)
+        lang = await storage.get_language(message.from_user.id, config.default_language)
+        await message.answer(t(lang, "driver.phone"))
+    else:
+        await state.update_data(photos=photos)
+
+
+@router.message(CreateTrip.photos)
+async def skip_photos(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    if message.text == SKIP[lang]:
+        await state.update_data(photos=[])
+        await state.set_state(CreateTrip.phone)
+        await message.answer(t(lang, "driver.phone"))
+    else:
+        await message.answer(t(lang, "driver.photos"))
+
+
+@router.message(CreateTrip.phone, F.contact)
+async def phone_contact(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    await state.update_data(phone=message.contact.phone_number)
+    await state.set_state(CreateTrip.comment)
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    await message.answer(t(lang, "driver.comment"))
 
 
 @router.message(CreateTrip.phone)
-async def set_phone(message: Message, state, storage: Storage):
+async def phone_text(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
     if not validate_phone(message.text):
-        await message.answer('Неверный формат телефона')
+        await message.answer(t(lang, "driver.phone"))
         return
-    data = await state.update_data(phone=message.text)
+    await state.update_data(phone=message.text)
+    await state.set_state(CreateTrip.comment)
+    await message.answer(t(lang, "driver.comment"))
+
+
+@router.message(CreateTrip.comment)
+async def set_comment(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    if message.text == SKIP[lang]:
+        await state.update_data(comment=None)
+    else:
+        await state.update_data(comment=message.text)
+    await state.set_state(CreateTrip.confirm)
+    data = await state.get_data()
+    preview = f"{data['from_city']} ➡️ {data['to_city']}\n{data['date']}"
+    if data.get('time'):
+        preview += f" {data['time'].strftime('%H:%M')}"
+    preview += f"\n{data['seats']} seats"
+    if data.get('price'):
+        preview += f" — {data['price']}"
+    else:
+        preview += f" — {AGREE[lang]}"
+    if data.get('car'):
+        preview += f"\n{data['car']}"
+    if data.get('comment'):
+        preview += f"\n{data['comment']}"
+    kb = build_keyboard([(t(lang, 'driver.confirm'), 'confirm:yes')])
+    await message.answer(preview, reply_markup=kb)
+
+
+@router.callback_query(CreateTrip.confirm, F.data == 'confirm:yes')
+async def confirm(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    data = await state.get_data()
     trip = Trip(
         id=uuid.uuid4(),
-        driver_id=message.from_user.id,
+        driver_id=callback.from_user.id,
         from_city=data['from_city'],
         to_city=data['to_city'],
-        departure_date=date.fromisoformat(data['departure_date']),
-        time=None,
-        seats=1,
-        price=None,
+        departure_date=data['date'],
+        time=data.get('time'),
+        seats=data['seats'],
+        price=data.get('price'),
         phone=data['phone'],
-        car=None,
-        photos=[],
-        comment=None,
+        car=data.get('car'),
+        photos=data.get('photos', []),
+        comment=data.get('comment'),
     )
     await storage.create_trip(trip)
-    await message.answer('Поездка создана')
+    await callback.message.edit_text('✅')
+    await callback.answer()
     await state.clear()

--- a/bot/handlers/followup.py
+++ b/bot/handlers/followup.py
@@ -1,9 +1,41 @@
-from aiogram import Router
+from __future__ import annotations
+
+import uuid
+
+from aiogram import F, Router
 from aiogram.types import CallbackQuery
+
+from ..config import Config
+from ..i18n import t
+from ..storage import Storage
+from ..utils import build_keyboard, schedule_followup
+from aiogram import Bot
 
 router = Router()
 
 
-@router.callback_query()
-async def show_number(callback: CallbackQuery):
-    await callback.answer('номер раскрыт')
+@router.callback_query(F.data.startswith("phone:"))
+async def show_phone(callback: CallbackQuery, storage: Storage, config: Config, bot: Bot) -> None:
+    trip_id = callback.data.split(":", 1)[1]
+    trip = await storage.get_trip(uuid.UUID(trip_id))
+    if not trip:
+        await callback.answer("❌")
+        return
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    await callback.message.answer(trip.phone)
+    await storage.record_contact(trip.id, callback.from_user.id)
+    follow_kb = build_keyboard([
+        (t(lang, 'followup.full'), f'full:{trip.id}'),
+        (t(lang, 'followup.not_yet'), f'wait:{trip.id}'),
+        (t(lang, 'followup.delete'), f'del:{trip.id}')
+    ])
+    await schedule_followup(bot, trip.driver_id, t(lang, 'followup.message'), config.followup_delay, follow_kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith(('full:', 'wait:', 'del:')))
+async def handle_follow(callback: CallbackQuery, storage: Storage) -> None:
+    action, trip_id = callback.data.split(":", 1)
+    if action == 'del' or action == 'full':
+        await storage.delete_trip(uuid.UUID(trip_id))
+    await callback.answer("✅")

--- a/bot/handlers/language.py
+++ b/bot/handlers/language.py
@@ -1,13 +1,45 @@
-from aiogram import Router
+from aiogram import Router, F
 from aiogram.filters import CommandStart
 from aiogram.types import Message, ReplyKeyboardMarkup, KeyboardButton
 
+from ..config import Config
+from ..i18n import t
+from ..storage import Storage
+
 router = Router()
+
+LANG_BUTTONS = {
+    '🇷🇺 Русский': 'ru',
+    '🇰🇬 Кыргызча': 'kg',
+}
+
+
+def main_menu(lang: str) -> ReplyKeyboardMarkup:
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text=t(lang, 'menu.create_trip')), KeyboardButton(text=t(lang, 'menu.search_trip'))],
+            [KeyboardButton(text=t(lang, 'menu.my_trips'))],
+        ],
+        resize_keyboard=True,
+    )
 
 
 @router.message(CommandStart())
-async def start(message: Message) -> None:
-    kb = ReplyKeyboardMarkup(
-        keyboard=[[KeyboardButton(text='🇷🇺'), KeyboardButton(text='🇰🇬')]], resize_keyboard=True
-    )
-    await message.answer('Выберите язык / Тилди тандаңыз', reply_markup=kb)
+async def cmd_start(message: Message, storage: Storage, config: Config) -> None:
+    lang = await storage.get_language(message.from_user.id, None)
+    if not lang:
+        kb = ReplyKeyboardMarkup(
+            keyboard=[[KeyboardButton(text=b) for b in LANG_BUTTONS]],
+            resize_keyboard=True,
+            one_time_keyboard=True,
+        )
+        await message.answer(t(config.default_language, 'start.choose_language'), reply_markup=kb)
+    else:
+        await message.answer(t(lang, 'start.choose_language'), reply_markup=main_menu(lang))
+
+
+@router.message(F.text.in_(LANG_BUTTONS.keys()))
+async def set_lang(message: Message, storage: Storage) -> None:
+    lang = LANG_BUTTONS[message.text]
+    await storage.set_language(message.from_user.id, lang)
+    await message.answer(t(lang, 'start.choose_language'), reply_markup=main_menu(lang))

--- a/bot/handlers/my_trips.py
+++ b/bot/handlers/my_trips.py
@@ -1,14 +1,31 @@
-from aiogram import Router, F
-from aiogram.types import Message
+from __future__ import annotations
+
+import uuid
+
+from aiogram import F, Router
+from aiogram.types import CallbackQuery, Message
+
 from ..storage import Storage
+from ..utils import build_keyboard
 
 router = Router()
 
 
-@router.message(F.text == '/my_trips')
-async def list_trips(message: Message, storage: Storage):
+@router.message(F.text.startswith("📋"))
+async def list_trips(message: Message, storage: Storage) -> None:
     trips = await storage.list_driver_trips(message.from_user.id)
     if not trips:
-        await message.answer('У вас нет активных поездок')
-    else:
-        await message.answer(f'У вас {len(trips)} поездок')
+        await message.answer("😔")
+        return
+    for trip in trips:
+        text = f"{trip.from_city} ➡️ {trip.to_city} {trip.departure_date}"
+        kb = build_keyboard([("🗑", f"del:{trip.id}")])
+        await message.answer(text, reply_markup=kb)
+
+
+@router.callback_query(F.data.startswith("del:"))
+async def delete_trip(callback: CallbackQuery, storage: Storage) -> None:
+    trip_id = callback.data.split(":", 1)[1]
+    await storage.delete_trip(uuid.UUID(trip_id))
+    await callback.answer("✅", show_alert=False)
+    await callback.message.delete()

--- a/bot/handlers/passenger.py
+++ b/bot/handlers/passenger.py
@@ -1,21 +1,116 @@
-from aiogram import Router, F
-from aiogram.types import Message
-from datetime import date
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from aiogram import F, Router
+from aiogram.filters.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, Message
+
+from ..config import Config
+from ..i18n import t
 from ..storage import Storage
+from ..utils import build_keyboard
 
 router = Router()
 
 
-@router.message(F.text == 'search')
-async def cmd_search(message: Message):
-    await message.answer('Из какого города?')
+class SearchRide(StatesGroup):
+    from_city = State()
+    to_city = State()
+    date = State()
+    time_pref = State()
 
 
-@router.message()
-async def handle_city(message: Message, storage: Storage):
-    # simplified search handler
-    trips = await storage.search_trips(message.text, message.text, date.today())
-    if not trips:
-        await message.answer('Не найдено')
+def city_kb(cfg: Config) -> list[tuple[str, str]]:
+    return [(c, f"scity:{c}") for c in cfg.cities]
+
+
+def time_kb(lang: str) -> list[tuple[str, str]]:
+    return [
+        ("🌅", "morning"),
+        ("🌇", "afternoon"),
+        ("🌆", "evening"),
+        ("🌃", "night"),
+    ]
+
+
+@router.message(F.text.startswith("🔎"))
+async def start_search(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    await state.set_state(SearchRide.from_city)
+    await message.answer(t(lang, "passenger.from_city"), reply_markup=build_keyboard(city_kb(config)))
+
+
+@router.callback_query(SearchRide.from_city, F.data.startswith("scity:"))
+async def set_from(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    await state.update_data(from_city=callback.data.split(":", 1)[1])
+    await state.set_state(SearchRide.to_city)
+    await callback.message.edit_text(t(lang, "passenger.to_city"), reply_markup=build_keyboard(city_kb(config)))
+    await callback.answer()
+
+
+@router.callback_query(SearchRide.to_city, F.data.startswith("scity:"))
+async def set_to(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    await state.update_data(to_city=callback.data.split(":", 1)[1])
+    await state.set_state(SearchRide.date)
+    buttons = [
+        ("Сегодня", "d:0"),
+        ("Завтра", "d:1"),
+        ("Введите дату", "d:manual"),
+    ]
+    await callback.message.edit_text(t(lang, "passenger.date"), reply_markup=build_keyboard(buttons))
+    await callback.answer()
+
+
+@router.callback_query(SearchRide.date, F.data.startswith("d:"))
+async def choose_date(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(callback.from_user.id, config.default_language)
+    data = callback.data.split(":", 1)[1]
+    if data == "manual":
+        await callback.message.edit_text(t(lang, "passenger.date") + " YYYY-MM-DD")
+        await state.set_state(SearchRide.date)
+        await state.update_data(manual_date=True)
+    else:
+        days = int(data)
+        await state.update_data(date=date.today() + timedelta(days=days), manual_date=False)
+        await state.set_state(SearchRide.time_pref)
+        await callback.message.edit_text(t(lang, "passenger.time"), reply_markup=build_keyboard(time_kb(lang)))
+    await callback.answer()
+
+
+@router.message(SearchRide.date)
+async def manual_date(message: Message, state: FSMContext, config: Config, storage: Storage) -> None:
+    lang = await storage.get_language(message.from_user.id, config.default_language)
+    try:
+        chosen = date.fromisoformat(message.text)
+    except ValueError:
+        await message.answer(t(lang, "passenger.date") + " YYYY-MM-DD")
         return
-    await message.answer(f'Найдено {len(trips)} поездок')
+    await state.update_data(date=chosen)
+    await state.set_state(SearchRide.time_pref)
+    await message.answer(t(lang, "passenger.time"), reply_markup=build_keyboard(time_kb(lang)))
+
+
+@router.callback_query(SearchRide.time_pref)
+async def show_rides(callback: CallbackQuery, state: FSMContext, config: Config, storage: Storage) -> None:
+    data = await state.get_data()
+    trips = await storage.search_trips(data['from_city'], data['to_city'], data['date'])
+    if not trips:
+        await callback.message.edit_text("😔")
+        await callback.answer()
+        await state.clear()
+        return
+    for trip in trips:
+        text = f"{trip.from_city} ➡️ {trip.to_city}\n{trip.departure_date}"
+        if trip.time:
+            text += f" {trip.time.strftime('%H:%M')}"
+        text += f"\n{trip.seats} seats"
+        if trip.price:
+            text += f" — {trip.price}"
+        kb = build_keyboard([("📞", f"phone:{trip.id}")])
+        await callback.message.answer(text, reply_markup=kb)
+    await callback.answer()
+    await state.clear()

--- a/bot/i18n.py
+++ b/bot/i18n.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def load_locales(path: str = 'bot/locales') -> Dict[str, Dict[str, str]]:
+    data: Dict[str, Dict[str, str]] = {}
+    for file in Path(path).glob('*.json'):
+        data[file.stem] = json.loads(file.read_text())
+    return data
+
+
+LOCALES = load_locales()
+
+
+def t(lang: str, key: str) -> str:
+    default = LOCALES.get('ru', {})
+    return LOCALES.get(lang, default).get(key, default.get(key, key))


### PR DESCRIPTION
## Summary
- add simple i18n loader
- implement multi-step ride posting flow
- implement passenger search flow with phone reveal follow-up
- implement ride management and language selection
- extend storage with user language support

## Testing
- `flake8`
- `python -m bot.main` *(fails: Token is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684016fb42bc83238bf22942d232180b